### PR TITLE
reputation fixes

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -4,8 +4,8 @@ government Enclave
 		
 	"player reputation" 1
 	"attitude toward"
-		"Merchant" 100
-		"Pirate" -1000
+		"Merchant" .25
+		"Pirate" -.3
 	bribe 0
 	"friendly hail" "friendly enclave"
 	"hostile hail" "hostile enclave"
@@ -14,10 +14,10 @@ government "XSZ Corporation"
 	swizzle 1
 	color .71 .41 .71
 		
-	"player reputation" 500
+	"player reputation" 1
 	"attitude toward"
-		"Merchant" 150
-		"Pirate" -10
+		"Merchant" .25
+		"Pirate" -.3
 	bribe 0
 	"friendly hail" "friendly xsz"
 	"hostile hail" "hostile xsz"


### PR DESCRIPTION
The value of a government's attitude towards another government shouldn't be too large or too small. Because of this, the XSZ can be friendly even if you joined the Enclave. This commit fixes that. I also don't get why the XSZ would trust the player too much at the start of the story.